### PR TITLE
remove temporary files after use

### DIFF
--- a/content_test.go
+++ b/content_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 )
@@ -30,6 +31,9 @@ func TestCreateContentFromString(t *testing.T) {
 
 func TestCreateContentFromFile(t *testing.T) {
 	f, err := ioutil.TempFile("", "")
+	if f != nil {
+		defer os.Remove(f.Name())
+	}
 	ok(t, err)
 	_, err = f.Write([]byte("Line1\nLine2"))
 	ok(t, err)

--- a/extedit.go
+++ b/extedit.go
@@ -35,6 +35,7 @@ func (s *Session) Invoke(content io.Reader) (Diff, error) {
 	if err != nil {
 		return d, err
 	}
+	defer os.Remove(fileName)
 
 	cmd := editorCmd(fileName)
 	err = cmd.Run()


### PR DESCRIPTION
It's up to the caller to remove the files created by ioutil.TempFile() after use, per the docs: https://golang.org/pkg/io/ioutil/#TempFile